### PR TITLE
Changed colors of text for dark mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ jekyll-help-center-theme-0.1.0.gem
 jekyll-help-center-theme.gemspec
 node_modules
 .DS_Store
+.bundle

--- a/docs/_sass/_base.scss
+++ b/docs/_sass/_base.scss
@@ -22,8 +22,8 @@ html {
 
 body {
   @media (prefers-color-scheme: dark) {
-    color: #515151;
-    background-color: #000;
+    color: #eee;
+    background-color: #111;
   }
   @media (prefers-color-scheme: light) {
     color: #515151;
@@ -49,8 +49,14 @@ h6 {
   margin-bottom: 0.5rem;
   font-weight: 600;
   line-height: 1.1;
-  color: #1a191b;
   letter-spacing: -0.025rem;
+  @media (prefers-color-scheme: dark) {
+    color: #ddd;
+  }
+  @media (prefers-color-scheme: light) {
+    color: #1a191b;
+  }
+
 }
 
 h1 {

--- a/docs/css/main.scss
+++ b/docs/css/main.scss
@@ -14,11 +14,17 @@ $baseurl: '{{ site.baseurl }}';
 @import "post";
 
 $dark-blue: rgb(11,0,128);
+$light-blue: rgb(51,204,255);
 
 .post-title { margin-top: 15px; }
 article p {
   a{
-    color: $dark-blue;
+    @media (prefers-color-scheme: dark) {
+      color: $light-blue;
+    }
+    @media (prefers-color-scheme: light) {
+      color: $dark-blue;
+    }
     text-decoration: none;
     &:hover {
       text-decoration: underline;


### PR DESCRIPTION
When I open the detail pages with dark mode, texts are also dark and it is difficult to read.
So I changed the text colors on detail pages.

ダークモード(macos)で個別のページを開くと、テキストも黒っぽくて読みにくかったのでスタイルを少し変えてみました。