### PR TITLE
Automate generating pages by GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: Test & Deploy
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: ☑️ Checkout code
+      uses: actions/checkout@v2
+
+    - name: 💎 Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true
+
+    - name: 🧪 Install gems
+      run: |
+        bundle config set with 'test'
+        bundle config set path 'vendor/bundle'
+        bundle install --jobs 4 --retry 3
+
+    - name: 🔧 Build & Test
+      run: |
+        cd ./docs
+        JEKYLL_ENV=production bundle exec jekyll build
+        bundle exec rake upsert_data_by_readme:all
+        bundle exec rake test
+
+    - name: 🚀 Deploy
+      if:   github.ref == 'refs/heads/master' && job.status == 'success'
+      run: |
+        cd ./docs
+        if [ -n "$(git status en ja --porcelain)" ]; then
+          git config user.name  "Yohei Yasukawa"
+          git config user.email "yohei@yasslab.jp"
+          git remote set-url origin https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
+          git checkout master
+          git add en ja
+          git commit -m '🤖 Generate page(s) by README'
+          git push origin master
+        fi


### PR DESCRIPTION
This PR enables to automate the following steps:

1. Generate pages by README[.en].md
2. Test generated static sites
3. Deploy them to GitHub Pages (https://remotework.jp/)

@uiur Glad if I automate generating pages for PRs like #187. What do you think? 👀 💭 

✅ Note: The new commit is generated on behalf of @yasulab account, not the creator of PR, because unfamiliar commit on behalf of the creator may confuse them. But if necessary, changing the following lines in this PR would work. 😌 

```diff
- git config user.name  "Yohei Yasukawa"
- git config user.email "yohei@yasslab.jp"
+ git config user.name  "${{ github.event.head_commit.author.name }}"
+ git config user.email "${{ github.actor }}@users.noreply.github.com"
```