### PR TITLE
Change default branch name: master -> main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Test & Deploy
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -32,15 +32,15 @@ jobs:
         bundle exec rake test
 
     - name: 🚀 Deploy
-      if:   github.ref == 'refs/heads/master' && job.status == 'success'
+      if:   github.ref == 'refs/heads/main' && job.status == 'success'
       run: |
         cd ./docs
         if [ -n "$(git status en ja --porcelain)" ]; then
           git config user.name  "Yohei Yasukawa"
           git config user.email "yohei@yasslab.jp"
           git remote set-url origin https://github-actions:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-          git checkout master
+          git checkout main
           git add en ja
           git commit -m '🤖 Generate page(s) by README'
-          git push origin master
+          git push origin main
         fi

--- a/README.en.md
+++ b/README.en.md
@@ -138,8 +138,8 @@ Please make sure the following condition are met to add your company to the list
 - Allow full/partial remote work
 
 Please add the company information to the following files
-- [README.md](https://github.com/remote-jp/remote-in-japan/blob/master/README.md) Japanese version
-- [README.en.md](https://github.com/remote-jp/remote-in-japan/blob/master/README.en.md) English version
+- [README.md](https://github.com/remote-jp/remote-in-japan/blob/main/README.md) Japanese version
+- [README.en.md](https://github.com/remote-jp/remote-in-japan/blob/main/README.en.md) English version
 
 Other files used in remotework.jp are automatically generated from the README, so you don't need to create separate files yourself.
 

--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Pull request 歓迎です。以下の条件を満たしていれば、積極的�
 
 会社の情報は、以下のファイルに追加してください
 
-- [README.md](https://github.com/remote-jp/remote-in-japan/blob/master/README.md) 日本語のバージョンです
-- [README.en.md](https://github.com/remote-jp/remote-in-japan/blob/master/README.en.md) 英語のバージョンです
+- [README.md](https://github.com/remote-jp/remote-in-japan/blob/main/README.md) 日本語のバージョンです
+- [README.en.md](https://github.com/remote-jp/remote-in-japan/blob/main/README.en.md) 英語のバージョンです
 
 [remotework.jp](https://remotework.jp/) で利用している他のファイルは README から自動生成されるため、READMEのみの追加でOKです
 


### PR DESCRIPTION
This PR will change default branch name from `master` to `main` with related files, such as GitHub Actions and links in README. 

I have contacted @uiur in advance of creating this PR and [confirmed to change it](https://twitter.com/yasulab/status/1436174582747000835). So I will merge this when test suites pass. :eyes: ✅ 

cf. :octocat: github/renaming - GitHub
https://github.com/github/renaming#readme
