### PR TITLE
Bump actions/checkout from v4 to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: ☑️ Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       # Need all commits to track info
       with:
         fetch-depth: 0


### PR DESCRIPTION
Update actions/checkout from v4 to v7 in the CI workflow.

fixes warnings: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/