### PR TITLE
feat: 検索した状態を URL で共有できるように ?q= パラメータを追加

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -17,32 +17,49 @@
      });
 
      // Company Search
-     const placeholders = ['Ruby', 'Python', 'PHP', 'iOS', 'Android', 'TypeScript', 'React', 'Vue', 'AWS', 'Django', 'Rails'];
+     // 検索フィールドは各言語のトップページにしか置かれていないため、無いページでは何もしない
+     const searchInput   = document.getElementById('search-input');
+     const searchResults = document.getElementById('search-results');
+     if (searchInput && searchResults) {
+       setRandomPlaceholder();
 
-     // Durstenfeld Shuffle Algorithm
-     // https://ja.wikipedia.org/wiki/フィッシャー–イェーツのシャッフル
-     for (i=placeholders.length; 1<i ; i--) {
-       j = Math.floor(Math.random() * i);
-       [placeholders[j], placeholders[i-1]] = [placeholders[i-1], placeholders[j]];
+       // JSON を先に読み込んでから初期化することで、?q= 付きで開いた時に即座に検索できる
+       fetch("/search-{{ lang }}.json")
+         .then((response) => {
+           if (!response.ok) throw new Error('HTTP ' + response.status);
+           return response.json();
+         })
+         .then((json)  => setupSearch(json))
+         .catch((error) => console.warn('検索データを読み込めませんでした:', error));
      }
 
-     let placeholder_text = "{{ site.data.translations['searchPlaceholder'][page.lang] }}";
-     placeholder_text    += placeholders[0] + ", " + placeholders[1] + ", " + placeholders[2];
-     document.getElementById("search-input").placeholder = placeholder_text;
+     function setRandomPlaceholder() {
+       const placeholders = ['Ruby', 'Python', 'PHP', 'iOS', 'Android', 'TypeScript', 'React', 'Vue', 'AWS', 'Django', 'Rails'];
 
-     const searchTarget = "/search-{{ lang }}.json";
-     const sjs = SimpleJekyllSearch({
-       searchInput:          document.getElementById('search-input'),
-       resultsContainer:     document.getElementById('search-results'),
-       json:                 searchTarget,
-       limit:                50,
+       // Durstenfeld Shuffle Algorithm
+       // https://ja.wikipedia.org/wiki/フィッシャー–イェーツのシャッフル
+       for (let i = placeholders.length; 1 < i; i--) {
+         const j = Math.floor(Math.random() * i);
+         [placeholders[j], placeholders[i-1]] = [placeholders[i-1], placeholders[j]];
+       }
 
-       searchResultTemplate: '<li class="search-result-item"><a href="{url}">{title}</a> <small><a href="{url}" class="description-link">{description} {full_remote}</a></small></li>',
-       noResultsText:        '{{ site.data.translations["searchNoResults"][page.lang] }}',
-       loadingText:          '{{ site.data.translations["searchLoading"][page.lang] }}',
+       let placeholder_text = "{{ site.data.translations['searchPlaceholder'][page.lang] }}";
+       placeholder_text    += placeholders[0] + ", " + placeholders[1] + ", " + placeholders[2];
+       searchInput.placeholder = placeholder_text;
+     }
 
-       // descriptionを100文字にtruncate. 100文字以下ならundefinedを返す（何も変えない）
-       templateMiddleware: function(prop, value, template) {
+     function setupSearch(json) {
+       const sjs = SimpleJekyllSearch({
+         searchInput:          searchInput,
+         resultsContainer:     searchResults,
+         json:                 json,
+         limit:                50,
+
+         searchResultTemplate: '<li class="search-result-item"><a href="{url}">{title}</a> <small><a href="{url}" class="description-link">{description} {full_remote}</a></small></li>',
+         noResultsText:        '{{ site.data.translations["searchNoResults"][page.lang] }}',
+
+         // descriptionを100文字にtruncate. 100文字以下ならundefinedを返す（何も変えない）
+         templateMiddleware: function(prop, value, template) {
 	 const query = document.getElementById('search-input').value.trim();
 
 	 // description にヒットしたら前後１００文字を表示
@@ -50,7 +67,7 @@
 	   if (query) {
 	     const regex       = new RegExp(escapeRegExp(query), 'i'); // case-insensitive
 	     const matchResult = regex.exec(value); // ← これでマッチと位置取得
-	     
+
 	     if (matchResult) {
                const matchIndex    = matchResult.index;
                const matchLength   = matchResult[0].length;
@@ -58,7 +75,7 @@
 
                let start = Math.max(0, matchIndex - Math.floor(desiredLength / 2));
                let end   = start + desiredLength;
-               
+
                // もし end が本文超えちゃうなら調整
                if (end > value.length) {
 		 end   = value.length;
@@ -91,10 +108,39 @@
 	 if (prop === 'full_remote' && typeof value === 'string') {
 	   return value.replace(new RegExp(escapeRegExp(query), 'gi'), '<mark>$&</mark>');
 	 }
-	 
+
 	 return value;
+         }
+       });
+
+       // ?q=Ruby のような URL で「検索した状態」をそのまま共有できるようにする
+       const query = new URLSearchParams(window.location.search).get('q');
+       if (query) {
+         searchInput.value = query;
+         sjs.search(query);
        }
-     });
+
+       // 入力に追随して URL を書き換え、いつでもその時点の検索結果を共有できるようにする。
+       // replaceState は短時間に繰り返し呼ぶと SecurityError を投げるブラウザがあるため、
+       // 入力が落ち着いてからまとめて書き換える
+       let urlUpdateTimer;
+       searchInput.addEventListener('input', () => {
+         clearTimeout(urlUpdateTimer);
+         urlUpdateTimer = setTimeout(() => updateQueryParam(searchInput.value), 300);
+       });
+     }
+
+     // 履歴を増やさずに ?q= だけを差し替える（空になったらパラメータごと消す）。
+     // 検索されるのは入力そのままの値なので、URL にも trim せずに入れて結果を一致させる
+     function updateQueryParam(query) {
+       const url = new URL(window.location.href);
+       if (query.trim()) {
+         url.searchParams.set('q', query);
+       } else {
+         url.searchParams.delete('q');
+       }
+       history.replaceState(null, '', url.toString());
+     }
 
      // 正規表現エスケープ用の関数
      function escapeRegExp(string) {


### PR DESCRIPTION

<img width="1778" height="1750" alt="image" src="https://github.com/user-attachments/assets/91105a79-8fe4-4b69-bc38-102e2c5e9440" />

https://remotework.jp/ja/?q=Rails

## 概要

検索した状態を URL で共有できるようにしました。これまで検索結果を指す URL がなく、検索結果をリンクで共有する手段がありませんでした。

- `/ja/?q=Ruby` のように開くと、検索フィールドに `Ruby` が入った状態で結果が表示されます
- 入力に追随して URL の `?q=` が書き換わるので、その時点の検索結果をそのままリンクとして共有できます
- 入力を空にすると `?q=` 自体が URL から消えます

未踏ジュニアの[採択プロジェクト検索](https://jr.mitou.org/projects/search?q=Web)と同じ使い勝手を目指しています。

## 実装メモ

同梱している Simple-Jekyll-Search は v1.4.1 で、JSON の読み込み完了を知る手段（`success` コールバック）がありません。`json:` に URL を渡す形のままでは `?q=` の検索を初期化直後に確実には実行できないため、**JSON を `fetch` で先に読み込み、パース済みの配列を渡して初期化する**形にしました。初期化時点でデータが揃っているため、直後に検索を実行できます。ライブラリ自体は変更していません。

- `replaceState` は短時間に繰り返し呼ぶと `SecurityError` を投げるブラウザがある（MDN の `History.replaceState` の例外に記載）ため、URL の書き換えには 300ms のデバウンスを挟んでいます
- URL に入れる値を `trim` すると検索された文字列と食い違いうる（`?q=Ruby+` と `?q=Ruby` で結果が変わりうる）ため、値はそのまま入れています

## あわせて修正した既存の問題

- 検索フィールドが無いページ（各社の個別ページ）で `placeholder` の代入が TypeError になり、以降のスクリプトが実行されていませんでした
- v1.4.1 が描画しない `loadingText` の指定を削除しました

## 動作確認

ヘッドレス Chrome でローカルビルドに対して確認しました。

- `/ja/?q=Ruby` `/?q=Rails` … フィールドに反映され、ハイライト付きで結果が表示される
- `?q=Ruby%20`（末尾スペース）… 手入力した時と結果件数が一致する
- 連打入力 … デバウンス後に最後の値で URL が更新される
- 空文字・空白のみ … `?q=` が URL から消える
- `bundle exec rake test`（html-proofer / 1038 ファイル）… 通過

## 補足

`?q=` 付きの URL が共有されると、クローラがトップページの重複 URL として辿る可能性があります。現状 `rel="canonical"` は無いため、別途 `_includes/head.html` への追加を検討する価値があります（この PR には含めていません）。
